### PR TITLE
[CLASSPATH] Using A Better Way To Detect if Platform is Windows 

### DIFF
--- a/lib/ruby/java/classpath.rb
+++ b/lib/ruby/java/classpath.rb
@@ -2,6 +2,7 @@ module Java
 
   class Classpath
     require 'pathname'
+    require 'rbconfig'
 
     def initialize(root_dir)
       @root = root_dir
@@ -20,7 +21,7 @@ module Java
     end
 
     def separator
-     PLATFORM['win32'] ? ";" : ":"
+     Config::CONFIG['host_os'] =~ /mswin|mingw/ ? ';' : ':'
     end
 
   end


### PR DESCRIPTION
I was getting the incorrect classpath for jruby and the C ruby
installers on Windows.  This was due to those two rubies not returning
'win32' for the platform.  So I've gone and used the technique outlined
at http://blog.emptyway.com/2009/11/03/proper-way-to-detect-windows-platform-in-ruby/
