### PR TITLE
Fix for remote backgrounding a task

### DIFF
--- a/lib/ruby/java/vm.rb
+++ b/lib/ruby/java/vm.rb
@@ -16,6 +16,7 @@ module Java
         else
           command << "&"
           command << " echo $! > #{options[:pid_file]}" if options[:pid_file]
+          command.unshift("nohup")
         end
       else
         command << "; echo $! > #{options[:pid_file]}" if options[:pid_file]


### PR DESCRIPTION
I have a user setup with ssh for executing tasks remotely using capistrano.  Instead of logging in as this user, I wanted to have capistrano handle the sudo request.

One of the tasks this user executes is to start a JVM on a remote machine, and put it into the background.

Without the 'nohup' command, the backgrounded task always dies when the remote connection is dropped.

HTH,
David
