### PR TITLE
Generate source jars as part of the build

### DIFF
--- a/lib/build/common-build.xml
+++ b/lib/build/common-build.xml
@@ -213,6 +213,17 @@
         </section>
       </manifest>
     </jar>
+    <jar jarfile="${dist}/lib/${artifact}-${version}-sources.jar" basedir="${build.src}">
+      <manifest>
+        <attribute name="Built-By" value="OpenQA.org"/>
+        <attribute name="Build-Time" value="${DSTAMP}${TSTAMP}"/>
+        <section name="common">
+          <attribute name="Specification-Title" value="${name}"/>
+          <attribute name="Specification-Version" value="${version}"/>
+          <attribute name="Specification-Vendor" value="OpenQA.org"/>
+        </section>
+      </manifest>
+    </jar>
   </target>
 
   <macrodef name="package-standalone-jar">


### PR DESCRIPTION
Source jars are very useful for debugging inside the IDE without needing to find and checkout the sources for each project
